### PR TITLE
Add kcp-adoption prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ var deletableResourceGroupPrefixes = []string{
 	"flannel-",
 	"ctrd-",
 	"capz-",
+	"kcp-adoption-",
 	"image-builder-e2e-",
 	"pkr-Resource-Group-",
 }


### PR DESCRIPTION
Adds the `kcp-adoption-` prefix to deleteable resource groups to include CAPI E2E running on Azure.

![Screen Shot 2021-02-08 at 11 13 13 AM](https://user-images.githubusercontent.com/8650424/107269590-aec9c300-69fe-11eb-8110-fd9f6b6ea1f8.png)


/assign @chewong 
