### PR TITLE
Add more acceptable RFC3339 layouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -168,10 +168,9 @@ func shouldDeleteResourceGroup(rg resources.Group, ttl time.Duration) (string, b
 	var err error
 	for _, layout := range rfc3339Layouts {
 		t, err = time.Parse(layout, *creationTimestamp)
-		if err != nil {
-			continue
+		if err == nil {
+			break
 		}
-		break
 	}
 
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -25,12 +25,25 @@ const (
 	subscriptionIDEnvVar  = "SUBSCRIPTION_ID"
 )
 
+var rfc3339Layouts = []string{
+	time.RFC3339,
+	time.RFC3339Nano,
+	// The following two layouts are also acceptable
+	// RFC3339 layouts. See:
+	// https://github.com/golang/go/issues/20555#issuecomment-440348440
+	"2006-01-02T15:04:05+0000",
+	"2006-01-02T15:04:05-0000",
+	"2006-01-02T15:04:05-00:00",
+	"2006-01-02T15:04:05+00:00",
+}
+
 // Consider resource groups with one of the following prefixes deletable
 var deletableResourceGroupPrefixes = []string{
 	"kubetest-",
 	"azuredisk-csi-driver-",
 	"azurefile-csi-driver-",
 	"blob-csi-driver-",
+	"blobfuse-csi-driver-",
 	"flannel-",
 	"ctrd-",
 	"capz-",
@@ -151,10 +164,21 @@ func shouldDeleteResourceGroup(rg resources.Group, ttl time.Duration) (string, b
 		return fmt.Sprintf("probably a long time because it does not have a '%s' tag", creationTimestampTag), true
 	}
 
-	t, err := time.Parse(time.RFC3339, *creationTimestamp)
+	var t time.Time
+	var err error
+	for _, layout := range rfc3339Layouts {
+		t, err = time.Parse(layout, *creationTimestamp)
+		if err != nil {
+			continue
+		}
+		break
+	}
+
 	if err != nil {
+		log.Printf("failed to parse timestamp: %s", err)
 		return "", false
 	}
+
 	return fmt.Sprintf("%d days", int(time.Since(t).Hours()/24)), time.Since(t) >= ttl
 }
 


### PR DESCRIPTION
This change adds more RFC3339 layouts. It appears there is an issue parsing RFC3339 in Go, and some acceptable layouts do not get parsed correctly. This change should account for a few more acceptable layouts.

Signed-off-by: Gabriel Adrian Samfira <gsamfira@cloudbasesolutions.com>