### PR TITLE
Handle listComplete error separately from Next()

### DIFF
--- a/main.go
+++ b/main.go
@@ -120,9 +120,13 @@ func main() {
 
 func run(ctx context.Context, r *resources.GroupsClient, ttl time.Duration, dryRun bool) error {
 	log.Println("Scanning for stale resource groups")
-	for list, err := r.ListComplete(ctx, "", nil); list.NotDone(); err = list.Next() {
+	listComplete, err := r.ListComplete(ctx, "", nil)
+	if err != nil {
+		return fmt.Errorf("Error when listing all resource groups: %v", err)
+	}
+	for list := listComplete; list.NotDone(); err = list.Next() {
 		if err != nil {
-			return fmt.Errorf("Error when listing all resource groups: %v", err)
+			return fmt.Errorf("Error when iterating resource groups: %v", err)
 		}
 
 		rg := list.Value()


### PR DESCRIPTION
Although this code followed the [example resource groups code](https://github.com/Azure-Samples/azure-sdk-for-go-samples/blob/main/services/resources/groups.go#L94), there is apparently a problem there where the initial error can be swallowed. Handling it separately seems to ensure it will be returned to the user as an error.

I tested locally with bad creds set in the environment variables.

Before:
```shell
% ./bin/rg-cleanup                                                           
2022/05/26 14:38:20 Initializing rg-cleanup
2022/05/26 14:38:20 Scanning for stale resource groups
```

After:
```shell
% ./bin/rg-cleanup                                                           
2022/05/26 14:37:33 Initializing rg-cleanup
2022/05/26 14:37:33 Scanning for stale resource groups
2022/05/26 14:37:34 Error when running rg-cleanup: Error when listing all resource groups: azure.BearerAuthorizer#WithAuthorization: Failed to refresh the Token for request to https://management.azure.com/subscriptions/redacted/resourcegroups?api-version=2018-05-01: StatusCode=400 -- Original Error: adal: Refresh request failed. Status Code = '400'. Response body: {"error":"invalid_request","error_description":"AADSTS900023: Specified tenant identifier 'redacted' is neither a valid DNS name, nor a valid external domain.\r\nTrace ID: 08c63805-1675-40a8-a4c8-a3a010993600\r\nCorrelation ID: 2bf53bf8-edf2-4d83-92b6-50b7e562ce91\r\nTimestamp: 2022-05-26 20:37:34Z","error_codes":[900023],"timestamp":"2022-05-26 20:37:34Z","trace_id":"08c63805-1675-40a8-a4c8-a3a010993600","correlation_id":"2bf53bf8-edf2-4d83-92b6-50b7e562ce91","error_uri":"https://login.microsoftonline.com/error?code=900023"}
```