### PR TITLE
Fix variable name typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-IMAGE_REGISTY ?= k8sprow.azurecr.io
+IMAGE_REGISTRY ?= k8sprow.azurecr.io
 IMAGE_NAME := rg-cleanup
 IMAGE_VERSION ?= v0.1.1
 


### PR DESCRIPTION
`IMAGE_REGISTRY` not `IMAGE_REGISTY`