### PR TITLE
Add --role-assignments flag to clean unattached RAs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Launch file",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "main.go",
+            "args": ["--ttl", "4h", "--az-cli", "--dry-run",],
+            "env": {
+                "SUBSCRIPTION_ID": "xxxxx-xxxx-xxxx-xxxx-xxxxx",
+            },
+        }
+
+    ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
-FROM alpine:3.18
-COPY bin/rg-cleanup /usr/local/bin
-ENTRYPOINT [ "rg-cleanup" ]
+FROM mcr.microsoft.com/cbl-mariner/base/core:2.0
+RUN tdnf install -y azure-cli jq && tdnf clean all
+COPY rg-cleanup.sh /usr/local/bin
+COPY bin/rg-cleanup ./bin
+ENTRYPOINT [ "rg-cleanup.sh" ]

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-IMAGE_REGISTRY ?= k8sprow.azurecr.io
+IMAGE_REGISTRY ?= k8sprowcomm.azurecr.io
 IMAGE_NAME := rg-cleanup
-IMAGE_VERSION ?= v0.2.0
+IMAGE_VERSION ?= v0.4.6
 
 .PHONY: all
 all: build

--- a/rg-cleanup.sh
+++ b/rg-cleanup.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Parse out --role-assignments flag
+role_assignments_flag=false
+while [[ "$#" -gt 0 ]]; do
+  case $1 in
+    --role-assignments) role_assignments_flag=true ;;
+    *) args+=("$1") ;;  # Store other arguments in an array
+  esac
+  shift
+done
+
+# Call resource group cleanup binary with its command-line arguments
+./bin/rg-cleanup "${args[@]}"
+
+# Exit if not cleaning up unattached role assignments
+if [ "$role_assignments_flag" != true ]; then
+  echo "Skipping unattached role assignment cleanup..."
+  exit 0
+fi
+
+# Clean up unattached role assignments
+az login --identity
+az account set --subscription "${SUBSCRIPTION_ID}"
+
+assignments=$(az role assignment list --scope "/subscriptions/$SUBSCRIPTION_ID" -o tsv --query "[?principalName==''].id")
+if [ -z "$assignments" ]; then
+  echo "No unattached role assignments found."
+  exit 0
+fi
+echo "Deleting unattached role assignments:"
+echo "$assignments"
+xargs az role assignment delete --ids <<< "$assignments"


### PR DESCRIPTION
Adds an optional `--role-assignments` flag to the container that will clean up unattached role assignments.

I tried to implement this all in the Go binary, but replicating the `az role assignments list` logic in go using the Graph API never quite worked, so instead I changed the container to run a shell script with the `az` command itself.